### PR TITLE
link to librt

### DIFF
--- a/src/cmake/cxxConfigure.cmake
+++ b/src/cmake/cxxConfigure.cmake
@@ -83,6 +83,9 @@ else  (HAVE_ZLIB)
     message(FATAL_ERROR "No support for gzip compression")
 endif (HAVE_ZLIB)
 
+# link librt
+set  (iSAAC_ADDITIONAL_LIB ${iSAAC_ADDITIONAL_LIB} rt)
+
 isaac_find_any_library(CPPUNIT "cppunit/config-auto.h" cppunit${CPPUNIT_DEBUG} "" "")
 
 isaac_find_boost(${iSAAC_BOOST_VERSION} "${iSAAC_BOOST_COMPONENTS}")


### PR DESCRIPTION
linking currently fails because librt isn't specified in the linker commands. This adds it, but doesn't check for its existence. This build process is a little more complicated than what I'm personally used to so there may be additional checks that are needed. This allowed us to compile on both Ubuntu 10.04 and 12.10.
